### PR TITLE
feat: add second script with module type

### DIFF
--- a/src/context/HubScriptInjector.tsx
+++ b/src/context/HubScriptInjector.tsx
@@ -23,7 +23,13 @@ type HubScriptInjectorProps = {
   locationHash?: string;
 };
 
-export default function HubScriptInjector({ appKey, hubUrlOverride, stateListener, locationHash, ...rest}: HubScriptInjectorProps) {
+export default function HubScriptInjector({
+  appKey,
+  hubUrlOverride,
+  stateListener,
+  locationHash,
+  ...rest
+}: HubScriptInjectorProps) {
   useEffect(() => {
     if (!window) {
       return; // compat with server-side rendering
@@ -62,15 +68,14 @@ export default function HubScriptInjector({ appKey, hubUrlOverride, stateListene
 
     if (rest) {
       Object.entries(rest).forEach(([key, value]) => {
-        setConfigValue(`set${key.charAt(0).toUpperCase() + key.substring(1)}`, value);
+        setConfigValue(
+          `set${key.charAt(0).toUpperCase() + key.substring(1)}`,
+          value
+        );
       });
       console.log('hubConfig:', window._rphConfig);
     }
-  }, [
-    appKey,
-    stateListener,
-    locationHash,
-  ]);
+  }, [appKey, stateListener, locationHash]);
 
   return null;
 }

--- a/src/context/HubScriptInjector.tsx
+++ b/src/context/HubScriptInjector.tsx
@@ -37,15 +37,21 @@ export default function HubScriptInjector({ appKey, hubUrlOverride, stateListene
     _rphConfig.push(['setBaseUrl', baseUrl]);
     var d = document,
       g = d.createElement('script'),
+      m = d.createElement('script'),
       s = d.getElementsByTagName('script')[0];
-    g.type = 'text/javascript';
+    g.noModule = true;
     g.async = true;
     g.src = baseUrl + '/static/scripts/rph.js';
+    m.type = 'module';
+    m.async = true;
+    m.src = baseUrl + '/static/scripts/rph.mjs';
 
     if (s?.parentNode) {
       s.parentNode.insertBefore(g, s);
+      s.parentNode.insertBefore(m, s);
     } else {
       d.body.appendChild(g);
+      d.body.appendChild(m);
     }
 
     setConfigValue('setAppKey', appKey);

--- a/src/context/RowndProvider.tsx
+++ b/src/context/RowndProvider.tsx
@@ -22,12 +22,9 @@ interface RowndProviderProps {
   hubUrlOverride?: string;
   postRegistrationUrl?: string;
   children: React.ReactNode;
-};
+}
 
-function RowndProvider({
-  children,
-  ...rest
-}: RowndProviderProps) {
+function RowndProvider({ children, ...rest }: RowndProviderProps) {
   const hubApi = useRef<{ [key: string]: any } | null>(null);
   const apiQueue = useRef<{ fnName: string; args: any[] }[]>([]);
 


### PR DESCRIPTION
- Adds a second script with `type="module"` to pull in a split version of the Rownd Hub bundle.
- Remove 'text/javascript' type from the existing script.
- Add `nomodule` attribute to the existing script to only pull the `.js` version if modules are not supported by the browser