### PR TITLE
Feat remix env

### DIFF
--- a/examples/remix/app/root.tsx
+++ b/examples/remix/app/root.tsx
@@ -4,11 +4,22 @@ import {
   Outlet,
   Scripts,
   ScrollRestoration,
+  useLoaderData,
 } from '@remix-run/react';
 import type { LinksFunction } from '@remix-run/node';
 
 import './tailwind.css';
 import { RemixRowndProvider } from '../../../src/remix';
+
+export const loader = async (): Promise<{ env: { ROWND_APP_KEY: string | undefined; ROWND_API_URL: string | undefined; ROWND_HUB_URL: string | undefined } }> => {
+  return {
+    env: {
+      ROWND_APP_KEY: process.env.ROWND_APP_KEY,
+      ROWND_API_URL: process.env.ROWND_API_URL,
+      ROWND_HUB_URL: process.env.ROWND_HUB_URL,
+    },
+  };
+};
 
 export const links: LinksFunction = () => [
   { rel: 'preconnect', href: 'https://fonts.googleapis.com' },
@@ -24,6 +35,7 @@ export const links: LinksFunction = () => [
 ];
 
 export function Layout({ children }: { children: React.ReactNode }) {
+  const { env } = useLoaderData<typeof loader>();
   return (
     <html lang="en">
       <head>
@@ -33,7 +45,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
         <Links />
       </head>
       <body>
-        <RemixRowndProvider appKey='YOUR_APP_KEY'>
+        <RemixRowndProvider appKey={env.ROWND_APP_KEY ?? ''} apiUrl={env.ROWND_API_URL} hubUrlOverride={env.ROWND_HUB_URL}>
           {children}
         </RemixRowndProvider>
         <ScrollRestoration />

--- a/examples/remix/app/routes/books/index.tsx
+++ b/examples/remix/app/routes/books/index.tsx
@@ -7,8 +7,8 @@ import {
 } from '../../../../../src/remix';
 
 type LoaderResponse = {
-  userId: string;
-  accessToken: string;
+  user_id: string;
+  access_token: string;
   posts: {
     userId: number;
     id: number;
@@ -19,19 +19,17 @@ type LoaderResponse = {
 
 export const loader: LoaderFunction = async ({
   request,
-}): Promise<LoaderResponse | { authenticated: boolean }> => {
-  const { accessToken, authenticated, userId } =
+}): Promise<LoaderResponse | { is_authenticated: boolean }> => {
+  const { access_token, is_authenticated, user_id } =
     await getRowndAuthenticationStatus(request.headers.get('Cookie'));
-  if (!authenticated) {
-    return { authenticated };
+  if (!is_authenticated) {
+    return { is_authenticated: false };
   }
 
-  const postsRes = await fetch(
-    'https://jsonplaceholder.typicode.com/posts',
-  );
+  const postsRes = await fetch('https://jsonplaceholder.typicode.com/posts');
   const posts = await postsRes.json();
 
-  return { userId, accessToken, posts };
+  return { user_id, access_token, posts };
 };
 
 function Index() {
@@ -46,23 +44,35 @@ function Index() {
           <h1 className="leading text-2xl font-bold text-gray-800 dark:text-gray-100">
             My books
           </h1>
-          <div className='flex flex-col gap-1'>
-          {posts.filter((_, idx) => idx < 5).map((post) => (
-            <div className='flex flex-col p-2' key={post.id}>
-              <h2>{post.title}</h2>
-              <p>{post.body}</p>
-            </div>
-          ))}
+          <div className="flex flex-col gap-1">
+            {posts
+              .filter((_, idx) => idx < 5)
+              .map((post) => (
+                <div className="flex flex-col p-2" key={post.id}>
+                  <h2>{post.title}</h2>
+                  <p>{post.body}</p>
+                </div>
+              ))}
           </div>
           {is_authenticated && <h1>User: {user.data.user_id}</h1>}
           <button
-            className='bg-blue-500 text-white px-4 py-2 rounded-md hover:bg-blue-600'
+            className="bg-blue-500 text-white px-4 py-2 rounded-md hover:bg-blue-600"
             onClick={() => (is_authenticated ? signOut() : requestSignIn())}
           >
             {is_authenticated ? 'Sign out' : 'Sign in'}
           </button>
-          <button className='bg-blue-500 text-white px-4 py-2 rounded-md hover:bg-blue-600' onClick={() => navigate('/profile')}>Link to profile</button>
-          <button className='bg-blue-500 text-white px-4 py-2 rounded-md hover:bg-blue-600' onClick={() => navigate('/')}>Link to home</button>
+          <button
+            className="bg-blue-500 text-white px-4 py-2 rounded-md hover:bg-blue-600"
+            onClick={() => navigate('/profile')}
+          >
+            Link to profile
+          </button>
+          <button
+            className="bg-blue-500 text-white px-4 py-2 rounded-md hover:bg-blue-600"
+            onClick={() => navigate('/')}
+          >
+            Link to home
+          </button>
         </header>
       </div>
     </div>

--- a/examples/remix/app/routes/books/index.tsx
+++ b/examples/remix/app/routes/books/index.tsx
@@ -1,8 +1,8 @@
-import type { LoaderFunction } from '@remix-run/node';
+import type { LoaderFunction, LoaderFunctionArgs } from '@remix-run/node';
 import { useLoaderData, useNavigate } from '@remix-run/react';
 import {
-  getRowndAuthenticationStatus,
   useRownd,
+  withRowndLoader,
   withRowndRequireSignIn,
 } from '../../../../../src/remix';
 
@@ -17,20 +17,12 @@ type LoaderResponse = {
   }[];
 };
 
-export const loader: LoaderFunction = async ({
-  request,
-}): Promise<LoaderResponse | { is_authenticated: boolean }> => {
-  const { access_token, is_authenticated, user_id } =
-    await getRowndAuthenticationStatus(request.headers.get('Cookie'));
-  if (!is_authenticated) {
-    return { is_authenticated: false };
-  }
-
+export const loader: LoaderFunction = withRowndLoader(async ({ request }: LoaderFunctionArgs, { user_id, access_token }) => {
   const postsRes = await fetch('https://jsonplaceholder.typicode.com/posts');
   const posts = await postsRes.json();
 
   return { user_id, access_token, posts };
-};
+});
 
 function Index() {
   const navigate = useNavigate();

--- a/examples/remix/app/routes/profile/index.tsx
+++ b/examples/remix/app/routes/profile/index.tsx
@@ -7,37 +7,39 @@ import {
 } from '../../../../../src/remix';
 
 type LoaderResponse = {
-  userId: string;
-  accessToken: string;
+  user_id: string;
+  access_token: string;
   profile: Record<string, any>;
 };
 
 export const loader: LoaderFunction = async ({
   request,
-}): Promise<LoaderResponse | { authenticated: boolean }> => {
-  const { accessToken, authenticated, userId } =
+  context,
+}): Promise<LoaderResponse | { is_authenticated: boolean }> => {
+  const { access_token, is_authenticated, user_id } =
     await getRowndAuthenticationStatus(request.headers.get('Cookie'));
-  if (!authenticated) {
-    return { authenticated };
+  
+  if (!is_authenticated) {
+    return { is_authenticated };
   }
 
   const profileRes = await fetch(
-    'https://api.rownd.io/me/applications/406650865825350227/data',
+    `${process.env.ROWND_API_URL}/me/applications/395599692981862989/data`,
     {
       headers: {
-        Authorization: `Bearer ${accessToken}`,
+        Authorization: `Bearer ${access_token}`,
       },
     }
   );
   const profile = await profileRes.json();
 
-  return { userId, accessToken, profile };
+  return { user_id, access_token, profile };
 };
 
 function Index() {
   const navigate = useNavigate();
   const { is_authenticated, user, requestSignIn, signOut } = useRownd();
-  const { userId, accessToken, profile } = useLoaderData<LoaderResponse>();
+  const { profile } = useLoaderData<LoaderResponse>();
 
   return (
     <div className="flex h-screen items-center justify-center">

--- a/examples/remix/app/routes/rownd-token-callback/index.tsx
+++ b/examples/remix/app/routes/rownd-token-callback/index.tsx
@@ -1,5 +1,0 @@
-import { ActionFunctionArgs } from "@remix-run/node";
-
-export const action = async ({ request }: ActionFunctionArgs) => {
-    return Response.json({ message: "Hello World" });
-}

--- a/examples/remix/app/routes/rownd-token-callback/index.tsx
+++ b/examples/remix/app/routes/rownd-token-callback/index.tsx
@@ -1,0 +1,5 @@
+import { ActionFunctionArgs } from "@remix-run/node";
+
+export const action = async ({ request }: ActionFunctionArgs) => {
+    return Response.json({ message: "Hello World" });
+}

--- a/src/remix/index.tsx
+++ b/src/remix/index.tsx
@@ -5,6 +5,7 @@ import withRowndRequireSignIn from './withRowndRequireSignIn';
 import {
   getRowndAuthenticationStatus,
   withRowndHandleRequest,
+  withRowndLoader,
 } from './server';
 
 export {
@@ -14,4 +15,5 @@ export {
   withRowndRequireSignIn,
   getRowndAuthenticationStatus,
   withRowndHandleRequest,
+  withRowndLoader,
 };

--- a/src/remix/server/index.ts
+++ b/src/remix/server/index.ts
@@ -1,4 +1,5 @@
 import { getRowndAuthenticationStatus } from './token';
 import { withRowndHandleRequest } from './withRowndActionHandler';
+import { withRowndLoader } from './withRowndLoader';
 
-export { getRowndAuthenticationStatus, withRowndHandleRequest };
+export { getRowndAuthenticationStatus, withRowndHandleRequest, withRowndLoader };

--- a/src/remix/server/withRowndLoader.tsx
+++ b/src/remix/server/withRowndLoader.tsx
@@ -1,0 +1,36 @@
+import { getRowndAuthenticationStatus } from './token';
+
+type LoaderFunctionArgs = {
+  request: Record<string, any>;
+  context: Record<string, any>;
+} & any;
+
+type RowndLoaderResponse =
+  | {
+      access_token: string;
+      is_authenticated: true;
+      user_id: string;
+    }
+  | {
+      access_token: undefined;
+      is_authenticated: false;
+      user_id: undefined;
+    };
+
+export const withRowndLoader = (
+  loader: (args: LoaderFunctionArgs, rowndResponse: RowndLoaderResponse) => Promise<any>
+) => {
+  return async function (args: LoaderFunctionArgs) {
+    const { request } = args;
+    const status = await getRowndAuthenticationStatus(
+      request.headers.get('Cookie')
+    );
+
+    if (!status.is_authenticated) {
+      return { is_authenticated: false };
+    }
+    return loader(args, {
+      ...status,
+    });
+  };
+};

--- a/src/remix/withRowndRequireSignIn.tsx
+++ b/src/remix/withRowndRequireSignIn.tsx
@@ -13,8 +13,8 @@ const withRowndRequireSignIn = <P extends object>(
     const data = useLoaderData();
 
     const isPropsFallbackEnabled = useMemo(
-      () => data?.authenticated === false,
-      [data?.authenticated]
+      () => data?.is_authenticated === false,
+      [data?.is_authenticated]
     );
 
     const cookieSignIn = useCallback(


### PR DESCRIPTION
- Update `getRowndAuthenticationStatus` to camel case `access_token , user_id, is_authenticated`
- Add env variable for `ROWND_API_URL` to handle different env's.
- Cache the Rownd keystore for 30mins
- Added hof for remix loader function

```jsx
export const loader = withRowndLoader(async function (
  { context, request }: LoaderFunctionArgs,
  { user_id, access_token }
) {

  const profileRes = await fetch(
    `${process.env.ROWND_API_URL}/me/applications/appId/data`,
    {
      headers: {
        Authorization: `Bearer ${access_token}`,
      },
    }
  );
  const profile = await profileRes.json();

  return { user_id, access_token, profile };
});
```